### PR TITLE
Adding parentheses to conditional in else

### DIFF
--- a/core/neat/functions/_neat-parse-columns.scss
+++ b/core/neat/functions/_neat-parse-columns.scss
@@ -16,7 +16,7 @@
   @if length($span) == 3 {
     $_total-columns: nth($span, 3);
     @return $_total-columns;
-  } @else if length($span) == 2 or if length($span) >= 3 {
+  } @else if length($span) == 2 or if(length($span) >= 3) {
     @error "`$column` should contain 2 values, seperated by an `of`";
   }
 }


### PR DESCRIPTION
Fix Issue #654 of Neat

When compiling using `sass` as taken from `npm i -g sass` (Dart Sass), this error is thrown:

```
Error: expected "(".
  } @else if length($span) == 2 or if (length($span) >= 3) {
                                     ^
  src/styles/0-plugins/neat/neat/functions/_neat-parse-columns.scss 19:38  root stylesheet
  src/styles/0-plugins/neat/_neat.scss 16:9                                @import
  src/styles/styles.sass 1:9                                               root stylesheet
  src/styles/0-plugins/_plugins.sass 2:9                                   @import
```

The relevant issue is #654. Adding parentheses fixes this issue.

Got some code for us? Awesome 🎊!

Please include a description of your change and the problem it solves. Then check your PR against this list. Thanks!
- [ ] Commit message has a short title & issue references
- [ ] Commits are squashed
- [ ] The build will pass (run `bundle exec rake`).

More info can be found by clicking the "guidelines for contributing" link above.
